### PR TITLE
Command `misawa` and `lgtm` needs prefix bot_name

### DIFF
--- a/scripts/lgtm.coffee
+++ b/scripts/lgtm.coffee
@@ -7,7 +7,7 @@
 util = require 'util'
 
 module.exports = (robot) ->
-  robot.hear /lgtm(?:\s*)$/i, (msg) ->
+  robot.respond /lgtm(?:\s*)$/i, (msg) ->
     msg.http('http://www.lgtm.in/g')
       .header('Accept', 'application/json')
       .get() (err, res, body) ->

--- a/scripts/misawa.coffee
+++ b/scripts/misawa.coffee
@@ -7,7 +7,7 @@
 
 util = require 'util'
 module.exports = (robot) ->
-  robot.hear /misawa(?:\s+)?(.+?)?(?:\s*)$/i, (msg) ->
+  robot.respond /misawa(?:\s+)?(.+?)?(?:\s*)$/i, (msg) ->
     msg.http('http://horesase-boys.herokuapp.com/meigens.json')
       .get() (err, res, body) ->
         if err


### PR DESCRIPTION
LGTMに反応し過ぎなので、
命令 `misawa`と`lgtm`はbot名を前置する必要があることにする。
