### PR TITLE
Add higanworks-url-title-check.coffee

### DIFF
--- a/scripts/higanworks-url-title-check.coffee
+++ b/scripts/higanworks-url-title-check.coffee
@@ -1,0 +1,34 @@
+# Description:
+#   Check URL Title
+#
+# Dependencies:
+#   "request": ""
+#   "cheerio": ""
+# 
+# Configuration:
+#   None
+#
+# Commands:
+#   None
+#
+# Notes:
+#   Check URL Title /^(https?:\/\/.*)/i
+#
+# Author:
+#   MATSUMOTO, Ryosuke
+
+request = require 'request'
+cheerio = require 'cheerio'
+ 
+module.exports = (robot) ->
+  robot.hear /(https?:\/\/.*)$/i, (msg) ->
+    url = msg.match[1]
+    options =
+      url: url
+      timeout: 2000
+      headers: {'user-agent': 'node title fetcher'}
+ 
+    request options, (error, response, body) ->
+      $ = cheerio.load body
+      title = $('title').text().replace(/\n/g, '')
+      msg.send(title)


### PR DESCRIPTION
メッセージにリンクがあれば、タイトルを表示するやつです。
IRCで使ってて便利だった。

https://github.com/higanworks/higanbot/blob/master/higanworks-url-title-check.coffee からのコピー
http://blog.matsumoto-r.jp/?p=4161 で紹介されてた。
