### PR TITLE
Remove redis-brain.coffee from the hubot-scripts.json file

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -1,1 +1,1 @@
-["redis-brain.coffee"]
+[]


### PR DESCRIPTION
Herokuへのdeployが失敗していたので、これかな？修正
https://www.npmjs.com/package/hubot-slack-timeline