### PR TITLE
Slackで投票補助をHubotにさせる

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -1,1 +1,1 @@
-["hubot-cron", "hubot-hotpepper"]
+["hubot-cron", "hubot-hotpepper", "hubot-slack-vote"]

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "hubot-hotpepper": "^0.1.4",
     "hubot-scripts": ">=2.16.2",
     "hubot-slack": "^3.3.0",
+    "hubot-slack-vote": "0.0.5",
     "request": "^2.65.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "url": "https://github.com/github/hubot.git"
   },
   "dependencies": {
-    "hubot": ">= 2.13.2",
+    "hubot": ">=2.16.0",
     "hubot-cron": "^0.2.9",
     "hubot-hotpepper": "^0.1.4",
-    "hubot-scripts": ">= 2.16.1",
+    "hubot-scripts": ">=2.16.2",
     "hubot-slack": "^3.3.0",
-    "request": "^2.58.0"
+    "request": "^2.65.0"
   },
   "engines": {
     "node": ">= 0.10.x",


### PR DESCRIPTION
### やったこと

[Slackのreactionを使った投票機能をhubot-scriptsで作った](http://qiita.com/akiray03/items/e649212d7749413365bd)をインストールしただけです。

必要な環境変数は、既に定義済だったのでそのまま使ってます。
### やれること

`forcechan vote :dog: :cat:` ってやると

![slack](https://cloud.githubusercontent.com/assets/7234418/10474582/37abd9d0-7273-11e5-8b31-957fcc5e2ed3.png)

上記のように `add reaction` をHubotがやってくれる。
賛成/反対的なやつをやりたいときに便利ですね。（あるのか？

`forcechan vote 崇めよ :pray:`
